### PR TITLE
Extract subtitles automatically using FFMpeg

### DIFF
--- a/grails-app/controllers/streama/VideoController.groovy
+++ b/grails-app/controllers/streama/VideoController.groovy
@@ -121,7 +121,7 @@ class VideoController {
     def file = uploadService.upload(request)
 
     if (file != null) {
-      videoInstance.addToFiles(file)
+      videoInstance.importFile(file)
       videoInstance.save flush: true, failOnError: true
       respond file
     } else {
@@ -161,7 +161,7 @@ class VideoController {
       return
     }
 
-    video.addToFiles(file)
+    video.importFile(file)
     video.save flush: true, failOnError: true
 
     respond status: OK
@@ -196,7 +196,7 @@ class VideoController {
       file.extension = matcher[0][0]
     }
     file.save()
-    videoInstance.addToFiles(file)
+    videoInstance.importFile(file)
     respond file
   }
 

--- a/grails-app/domain/streama/File.groovy
+++ b/grails-app/domain/streama/File.groovy
@@ -79,6 +79,10 @@ class File {
     }
   }
 
+  boolean isVideo() {
+    return extension != '.srt' && extension != '.vtt';
+  }
+
   def getSimpleInstance(){
     return [
         id: this.id,

--- a/grails-app/domain/streama/Video.groovy
+++ b/grails-app/domain/streama/Video.groovy
@@ -3,6 +3,7 @@ package streama
 class Video {
 
   def springSecurityService
+  def transcodeService
   transient videoService
 
   Date dateCreated
@@ -112,6 +113,19 @@ class Video {
     }else{
       return imagePath
     }
+  }
+
+  def importFile(File f) {
+    def filesToImport = [f]
+
+    if (f.isVideo() && TranscodeService.canTranscode()) {
+      transcodeService.transcodeSubtitles(f).each {
+        it.save()
+        filesToImport.add(it)
+      }
+    }
+
+    filesToImport.each { this.addToFiles(it) }
   }
 
 

--- a/grails-app/services/streama/TranscodeService.groovy
+++ b/grails-app/services/streama/TranscodeService.groovy
@@ -1,0 +1,86 @@
+package streama
+
+import grails.transaction.Transactional
+import groovy.json.JsonSlurper
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+@Transactional
+class TranscodeService {
+
+  def settingsService
+
+  private static final String subtitlePath = null;
+  private static final boolean CAN_TRANSCODE = false;
+
+  // Access this field to determine whether or not transcoding is available
+  public static boolean canTranscode() { return CAN_TRANSCODE; }
+
+  static {
+    // We can transcode if we have actual ffmpeg. Results won't necessarily work if we have
+    // libav bastard version of ffmpeg
+    CAN_TRANSCODE = ['ffmpeg', '-version'].execute().getText().startsWith('ffmpeg')
+    CAN_TRANSCODE = CAN_TRANSCODE && ['ffprobe', '-version'].execute().getText().startsWith('ffprobe')
+
+    def uDir = Settings.findBySettingsKey('Upload Directory')?.value;
+    if (!uDir) {
+      CAN_TRANSCODE = false;
+    } else {
+      subtitlePath = uDir + java.io.File.separatorChar + 'transcodedSubtitles'
+      def d = new java.io.File(uDir)
+      if (!d.exists()) {
+        System.out.println("Creating subtitle transcoding directory: " + uDir)
+        d.mkdirs()
+      }
+    }
+  }
+
+  List<File> transcodeSubtitles(File videoFile) {
+    def returnFiles = []
+
+    def fileIdent = videoFile.localFile
+      .split("$java.io.File.separatorChar")[-1]
+      .split('\\.')[0..-2].join('.').replace(' ', '_')
+
+    System.out.println(fileIdent)
+
+    def ffProbeCmd = ['ffprobe',
+                      '-i', videoFile.localFile,
+                      '-show_streams',
+                      '-show_format',
+                      '-print_format', 'json']
+
+    def probe = new JsonSlurper().parseText(ffProbeCmd.execute().getText())
+    def subStreams = probe.streams.findAll { it.codec_type.equals("subtitle") }
+
+    System.out.println(subStreams)
+
+    subStreams.each {
+      def finalPath = subtitlePath + java.io.File.separatorChar + fileIdent + '_s-' + it.index + '.vtt'
+      System.out.println('transcoding ' + finalPath +'!')
+      def ffMpegCmd = ['ffmpeg', '-i', videoFile.localFile, '-map', '0:' + it.index, '-f', 'webvtt', finalPath]
+      def ffProc = ffMpegCmd.execute()
+      ffProc.waitFor()
+      if (ffProc.exitValue() == 0) {
+        System.out.println("Successfully converted " + finalPath + "!")
+        def newFile = new File()
+        newFile.localFile = finalPath
+        newFile.originalFilename = finalPath
+        newFile.contentType = "text/vtt"
+        newFile.subtitleLabel = it.title
+        newFile.subtitleSrcLang = it.language
+        newFile.size = Files.size(Paths.get(finalPath))
+        newFile.extension = ".vtt"
+        returnFiles.add(newFile)
+      } else {
+        System.out.println("Failed conversion: ")
+        System.out << ffProc.errorStream
+        System.out.flush()
+        new java.io.File(finalPath)?.delete()
+      }
+    }
+
+    return returnFiles
+  }
+}

--- a/grails-app/services/streama/TranscodeService.groovy
+++ b/grails-app/services/streama/TranscodeService.groovy
@@ -57,7 +57,8 @@ class TranscodeService {
     System.out.println(subStreams)
 
     subStreams.each {
-      def finalPath = subtitlePath + java.io.File.separatorChar + fileIdent + '_s-' + it.index + '.vtt'
+      def fileName = fileIdent + '_s-' + it.index + '.vtt'
+      def finalPath = subtitlePath + java.io.File.separatorChar + fileName
       System.out.println('transcoding ' + finalPath +'!')
       def ffMpegCmd = ['ffmpeg', '-i', videoFile.localFile, '-map', '0:' + it.index, '-f', 'webvtt', finalPath]
       def ffProc = ffMpegCmd.execute()
@@ -66,10 +67,11 @@ class TranscodeService {
         System.out.println("Successfully converted " + finalPath + "!")
         def newFile = new File()
         newFile.localFile = finalPath
-        newFile.originalFilename = finalPath
+        newFile.originalFilename = fileName
         newFile.contentType = "text/vtt"
-        newFile.subtitleLabel = it.title
-        newFile.subtitleSrcLang = it.language
+        // These may not be reliable... depends on who encoded the file.
+        newFile.subtitleLabel = it.tags.title == null ? "Embedded Subtitles" : it.tags.title
+        newFile.subtitleSrcLang = it.tags.language
         newFile.size = Files.size(Paths.get(finalPath))
         newFile.extension = ".vtt"
         returnFiles.add(newFile)

--- a/grails-app/services/streama/VideoService.groovy
+++ b/grails-app/services/streama/VideoService.groovy
@@ -76,7 +76,7 @@ class VideoService {
     def extensionIndex = params.localFile.lastIndexOf('.')
     file.extension = params.localFile[extensionIndex..-1];
     file.save(failOnError: true, flush: true)
-    videoInstance.addToFiles(file)
+    videoInstance.importFile(file)
     videoInstance.save(failOnError: true, flush: true)
     return file
   }

--- a/src/test/groovy/streama/TranscodeServiceSpec.groovy
+++ b/src/test/groovy/streama/TranscodeServiceSpec.groovy
@@ -1,0 +1,22 @@
+package streama
+
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
+/**
+ * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions
+ */
+@TestFor(TranscodeService)
+class TranscodeServiceSpec extends Specification {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+        expect:"fix me"
+            true == false
+    }
+}


### PR DESCRIPTION
This is a PoC and starting-point for converting embedded subtitles (fix #210) to WebVTT using FFMpeg. Currently, I'm just extracting all subtitle tracks and converting to VTT when a video file is added (since WebVTT is the only format HTML5 video players can understand). Let's start a conversation about where this functionality could go, and possibly about how to architect a good transcoding story overall. (I'm on Discord, same username).

This works pretty well on the TV episodes I've tried.

## New Requirements

- ffmpeg is required to perform transcoding (real ffmpeg, not the libav port). If ffmpeg is not available, `TranscodeService.canTranscode()` will return `false`

## Architecture

- Replaced all occurrences of `Video.addToFiles()` with `Video.importFiles()`
- if a file is a video, `TranscodeService` is used to extract the subtitle tracks into separate VTT files (directory: `$uploadDirectory/transcodedSubtitles`)
- use `ffprobe` to get the indices of each track and `ffmpeg` to convert each track to WebVTT.
- Add the entire bundle of video files and extracted subtitle files to the `Video` object we called from (set subtitle language and title if available in the JSON metadata from ffprobe)
- Discard any failed conversions

## Caveats

Here's the quick list of known bugs and deficiencies that I'll have to fix before you can merge this:

- For reasons I can't ascertain, bulk add files no longer creates "show" entries in the dashboard. The shows are created in the database but they don't display on the dashboard, after applying this patch.
- Adding a video file blocks on transcoding the subtitles, which take a couple of seconds each for a 30 minute TV episode, more for a movie. Some videos have multiple subtitle tracks, and there's currently not any indication to the user that the transcode is taking place
- Transcoding subtitles is currently not optional. It should probably be exposed in settings (and possibly made optional for each upload)
- I had to make the directory for the subtitles manually, as (grails-app/services/streama/TranscodeService.groovy:34 `d.mkdirs()` seems not to do anything)
- The TranscodeService class crashes grails if it attempts to dynamically recompile the class (I suspect this is because of its static constructor, but why?)
- If conversion fails, the user has no way to know this
- There's some `println` left that should get properly logged.
- How do we test this?
- I don't really know Groovy/Grails, so the code is probably very Java-ish, which may not be what you want


Signed-off-by: William Temple <William.Temple@colorado.edu>