### PR TITLE
Create 'user' -> 'users' migration script for mysql databases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,15 +99,12 @@ dependencies {
     compile "org.grails.plugins:grails-spring-websocket:2.3.0"
     compile group: 'eu.bitwalker', name: 'UserAgentUtils', version: '1.20'
     runtime 'mysql:mysql-connector-java:5.1.36'
-<<<<<<< HEAD
     //compile group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
     //runtime 'org.postgresql:postgresql:42.2.3'
     // as per instructions @ https://github.com/kaleidos/grails-postgresql-extensions/blob/master/README.md
     //compile 'org.grails.plugins:postgresql-extensions:5.2.0'
     //provided 'org.postgresql:postgresql:42.1.4'
 
-=======
->>>>>>> parent of ff299c4... add initial changes for postgres support
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ ext {
 repositories {
     mavenLocal()
     maven { url "https://repo.grails.org/grails/core" }
+    jcenter()
 }
 
 dependencyManagement {
@@ -99,6 +100,12 @@ dependencies {
     compile "org.grails.plugins:grails-spring-websocket:2.3.0"
     compile group: 'eu.bitwalker', name: 'UserAgentUtils', version: '1.20'
     runtime 'mysql:mysql-connector-java:5.1.36'
+    compile group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
+    //runtime 'org.postgresql:postgresql:42.1.4'
+    // as per instructions @ https://github.com/kaleidos/grails-postgresql-extensions/blob/master/README.md
+    compile 'org.grails.plugins:postgresql-extensions:5.2.0'
+    //provided 'org.postgresql:postgresql:42.1.4'
+
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -100,10 +100,10 @@ dependencies {
     compile "org.grails.plugins:grails-spring-websocket:2.3.0"
     compile group: 'eu.bitwalker', name: 'UserAgentUtils', version: '1.20'
     runtime 'mysql:mysql-connector-java:5.1.36'
-    compile group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
-    //runtime 'org.postgresql:postgresql:42.1.4'
+    //compile group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
+    runtime 'org.postgresql:postgresql:42.2.2'
     // as per instructions @ https://github.com/kaleidos/grails-postgresql-extensions/blob/master/README.md
-    compile 'org.grails.plugins:postgresql-extensions:5.2.0'
+    //compile 'org.grails.plugins:postgresql-extensions:5.2.0'
     //provided 'org.postgresql:postgresql:42.1.4'
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     compile group: 'eu.bitwalker', name: 'UserAgentUtils', version: '1.20'
     runtime 'mysql:mysql-connector-java:5.1.36'
     //compile group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
-    runtime 'org.postgresql:postgresql:42.2.2'
+    runtime 'org.postgresql:postgresql:42.2.3'
     // as per instructions @ https://github.com/kaleidos/grails-postgresql-extensions/blob/master/README.md
     //compile 'org.grails.plugins:postgresql-extensions:5.2.0'
     //provided 'org.postgresql:postgresql:42.1.4'

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ ext {
 repositories {
     mavenLocal()
     maven { url "https://repo.grails.org/grails/core" }
-    jcenter()
 }
 
 dependencyManagement {
@@ -100,12 +99,15 @@ dependencies {
     compile "org.grails.plugins:grails-spring-websocket:2.3.0"
     compile group: 'eu.bitwalker', name: 'UserAgentUtils', version: '1.20'
     runtime 'mysql:mysql-connector-java:5.1.36'
+<<<<<<< HEAD
     //compile group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
-    runtime 'org.postgresql:postgresql:42.2.3'
+    //runtime 'org.postgresql:postgresql:42.2.3'
     // as per instructions @ https://github.com/kaleidos/grails-postgresql-extensions/blob/master/README.md
     //compile 'org.grails.plugins:postgresql-extensions:5.2.0'
     //provided 'org.postgresql:postgresql:42.1.4'
 
+=======
+>>>>>>> parent of ff299c4... add initial changes for postgres support
 }
 
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -99,11 +99,13 @@ dependencies {
     compile "org.grails.plugins:grails-spring-websocket:2.3.0"
     compile group: 'eu.bitwalker', name: 'UserAgentUtils', version: '1.20'
     runtime 'mysql:mysql-connector-java:5.1.36'
-    //compile group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
+    // runtime for postgresql works fine
+    // but compile group kept for testing as per closed pull request #368
+    //compile group: 'org.postgresql', name: 'postgresql', version: '42.2.3'
     //runtime 'org.postgresql:postgresql:42.2.3'
     // as per instructions @ https://github.com/kaleidos/grails-postgresql-extensions/blob/master/README.md
+    // streama seems to work fine without it though
     //compile 'org.grails.plugins:postgresql-extensions:5.2.0'
-    //provided 'org.postgresql:postgresql:42.1.4'
 
 }
 

--- a/grails-app/domain/streama/User.groovy
+++ b/grails-app/domain/streama/User.groovy
@@ -37,6 +37,8 @@ class User {
 	}
 
 	static mapping = {
+       		//User is reserved keyword in some systems, like PostgreSQL
+	       	table 'users'	
 		password column: '`password`'
 		cache true
 	}

--- a/grails-app/domain/streama/User.groovy
+++ b/grails-app/domain/streama/User.groovy
@@ -37,8 +37,6 @@ class User {
 	}
 
 	static mapping = {
-       		//User is reserved keyword in some systems, like PostgreSQL
-	       	table 'users'	
 		password column: '`password`'
 		cache true
 	}

--- a/migration-scripts/mysql-table-user-to-users.sh
+++ b/migration-scripts/mysql-table-user-to-users.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# get streama database user name, password and DB name for mysql
+echo input mysql user name for streama database:
+read -s USER
+echo ''
+echo input mysql user password for streama database:
+read -s PASS
+echo ''
+echo input mysql database name for streama database:
+read -s D
+echo ''
+
+# check for 'user'/'users' table
+if [ -z "$(mysql -u $USER --password=$PASS -D $DB -e "show tables like 'user'")" ]; then
+	echo "'user' table does not exist"
+	if [ -z "$(mysql -u $USER --password=$PASS -D $DB -e "show tables like 'users'")" ]; then
+		echo "'users' table does not exist either"
+		echo "there is an issue with your streama database"
+	else
+		echo "'users table exists'"
+		echo "no need to rename table"
+	fi
+
+else
+	echo "'user' table exists"
+	echo "renaming 'user' table to 'users'"
+	mysql -u $USER --password=$PASS -D $DB -e "ALTER TABLE user RENAME users"
+        if [ -z "$(mysql -u $USER --password=$PASS -D $DB -e "show tables like 'users'")" ]; then
+		echo "rename failed"
+	else
+		echo "rename succeeded"
+	fi
+
+fi
+
+echo ""
+echo "finished"

--- a/migration-scripts/mysql-table-user-to-users.sh
+++ b/migration-scripts/mysql-table-user-to-users.sh
@@ -8,7 +8,7 @@ echo input mysql user password for streama database:
 read -s PASS
 echo ''
 echo input mysql database name for streama database:
-read -s D
+read -s DB
 echo ''
 
 # check for 'user'/'users' table


### PR DESCRIPTION
This bash migration script takes necessary user input (mysql user name, mysql DB name, and mysql password) and checks whether the `user` or `users` table exists for a streama mysql database. If `user` table exists, rename it to `users` and notify the user. If `users` exists, do nothing and notify the user. If neither `user` nor `users` exist for some reason, notify the user.

This script will help mysql users with the breaking changes discussed in issue #409. 

The postgresql database dependency has been added to `build.gradle`, but is commented out for the time being.