### PR TITLE
Moving Bootstrap.groovy to be within the streama package

### DIFF
--- a/grails-app/init/streama/BootStrap.groovy
+++ b/grails-app/init/streama/BootStrap.groovy
@@ -1,3 +1,5 @@
+package streama
+
 class BootStrap {
 
     def marshallerService


### PR DESCRIPTION
Fixes the issue outline in #395 when running the streama server:
ERROR grails.boot.config.tools.ClassPathScanner - The application defines a Groovy source using the default package. Please move all Groovy sources into a package.