### PR TITLE
Disable volume control using mouse wheel on episode list (fix #315)

### DIFF
--- a/grails-app/assets/javascripts/streama/directives/streama-video-player-directive.js
+++ b/grails-app/assets/javascripts/streama/directives/streama-video-player-directive.js
@@ -448,7 +448,11 @@ angular.module('streama').directive('streamaVideoPlayer', [
 
 
 				function initMouseWheel() {
+				  var isMouseWheelVolumeCtrlActive = true;
 					jQuery($elem).mousewheel(function (event) {
+					  if (!isMouseWheelVolumeCtrlActive) {
+					    return;
+					  }
 						if (event.deltaY > 0) {
 							changeVolume(1);
 						} else if (event.deltaY < 0) {
@@ -456,6 +460,13 @@ angular.module('streama').directive('streamaVideoPlayer', [
 						}
 						$scope.showControls();
 					});
+				  var playerMenu = document.querySelector('#player-menu-episode-selector');
+				  playerMenu.addEventListener('mouseenter', function (event) {
+				    isMouseWheelVolumeCtrlActive = false;
+				  });
+				  playerMenu.addEventListener('mouseleave', function (event) {
+				    isMouseWheelVolumeCtrlActive = true;
+				  });
 				}
 
 				function initMousetrap() {


### PR DESCRIPTION
Add active flag judgment processing to mouse-wheel event handler method. This flag is set to false when the mouse cursor is on the episode list and to be true when leaving.

It seems that the indent setting of editorconfig and the indent of this file do not become consistent.
