### PR TITLE
added resetting of playback when near the end of a file

### DIFF
--- a/grails-app/assets/javascripts/streama/directives/streama-video-player-directive.js
+++ b/grails-app/assets/javascripts/streama/directives/streama-video-player-directive.js
@@ -321,6 +321,9 @@ angular.module('streama').directive('streamaVideoPlayer', [
             }
             $scope.videoDuration = video.duration;
             video.currentTime = $scope.options.customStartingTime || 0;
+            if($scope.options.outro_start ? $scope.options.outro_start < video.currentTime : video.duration - video.currentTime < 120) {
+              video.currentTime = 0
+            }
             $scope.currentTime = video.currentTime;
             $scope.initialPlay = true;
             if ($scope.options.videoTrack) {


### PR DESCRIPTION
As discussed in #713. I  changed the time to a bigger value as, in my experience, most videos have 3+ minutes of credits. I think it also could be a good approach to make the value a percentage of the overall movie, like `video.duration * 1000 / video.currentTime * 10 < ourSetValue` where we could  the set something like `ourSetValue = 995` for 99.5% of the Video.