### PR TITLE
added support for automatic episode switching on the dash for series

### DIFF
--- a/grails-app/services/streama/VideoService.groovy
+++ b/grails-app/services/streama/VideoService.groovy
@@ -67,21 +67,24 @@ class VideoService {
     continueWatching.each { continueWatchingItem ->
       if (continueWatchingItem.video instanceof Episode) {
         ViewingStatus next = continueWatchingItem.video.getNextEpisode()?.getViewingStatus()
-        if(next != null) {
-          ViewingStatus newnext = new ViewingStatus() // we need a new opject
+
+        if(next != null) { // if a viewing status exists reset it to 0
+          ViewingStatus newnext = new ViewingStatus() // we need a new opject so the episode list still works
           InvokerHelper.setProperties(newnext, next.properties)
           next = newnext
-
-          next.currentPlayTime = 0
-          if(continueWatchingItem.video.outro_start != null) {
-            if(continueWatchingItem.video.outro_start <= continueWatchingItem.currentPlayTime) {
-              result.add(next)
-              return
-            }
-          } else if (continueWatchingItem.runtime && continueWatchingItem.currentPlayTime * 100 / continueWatchingItem.runtime > 95) {
+        } else {
+          next = new ViewingStatus()
+          next.video = continueWatchingItem.video.getNextEpisode()
+        }
+        next.currentPlayTime = 0
+        if(continueWatchingItem.video.outro_start != null) {
+          if(continueWatchingItem.video.outro_start <= continueWatchingItem.currentPlayTime) {
             result.add(next)
             return
           }
+        } else if (continueWatchingItem.runtime && continueWatchingItem.currentPlayTime * 100 / continueWatchingItem.runtime > 95) {
+          result.add(next)
+          return
         }
       }
       // default case, also adds non-applicable episodes

--- a/grails-app/services/streama/VideoService.groovy
+++ b/grails-app/services/streama/VideoService.groovy
@@ -7,6 +7,8 @@ import org.grails.web.util.WebUtils
 import java.nio.file.Files
 import java.nio.file.Paths
 
+import org.codehaus.groovy.runtime.InvokerHelper
+
 import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE
 import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE
 
@@ -66,6 +68,10 @@ class VideoService {
       if (continueWatchingItem.video instanceof Episode) {
         ViewingStatus next = continueWatchingItem.video.getNextEpisode()?.getViewingStatus()
         if(next != null) {
+          ViewingStatus newnext = new ViewingStatus() // we need a new opject
+          InvokerHelper.setProperties(newnext, next.properties)
+          next = newnext
+
           next.currentPlayTime = 0
           if(continueWatchingItem.video.outro_start != null) {
             if(continueWatchingItem.video.outro_start <= continueWatchingItem.currentPlayTime) {


### PR DESCRIPTION
I'm not sure this is good as is, so please correct me if I did anything dumb. I'm closing #713 in favor of this, even though the resetting for explicitly chosen episodes (and movies as well) is not yet implemented. I'm pretty happy with the functionality this provides and I think it does well UX-wise.

To elaborate a bit: All this does is change the episode shown on the dash in 'continue watching' and reset that episodes time to 0, but only visually and only if the previous episode was nearly over. I also attempt to read the `outro_start` value, although I'm not sure how well this is supported by TMDB. The actual status of the episode isn't changed until the user clicks on it. 