### PR TITLE
[WIP] Better regex for movie match

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -152,7 +152,7 @@ grails:
 
 streama:
   regex:
-    movies: ^(?<Name>.*)?[._ \(]+(?<Year>\d{4}).*
+    movies: ^(?<Name>[^\(\[]*)?[._ \(\[]+(?<Year>\d{4}).*
     shows:
       - ^(?<Name>.+)[._ ][Ss](?<Season>\d{2})[Ee](?<Episode>\d{2,3}).*      # example:  "House.MD.S03E04.h264.mp4"
       - ^(?<Name>.+)[._ ](?<Season>\d{1,2})x(?<Episode>\d{2,3}).*           # example:  "House.MD.03x04.h264.mp4"

--- a/grails-app/services/streama/BulkCreateService.groovy
+++ b/grails-app/services/streama/BulkCreateService.groovy
@@ -50,6 +50,7 @@ class BulkCreateService {
 
   private matchSingleFile(file, movieRegex, List tvShowRegexList) {
     def fileResult = [file: file.path]
+    def foundMatch = false
 
     String fileName = file.name
 
@@ -58,13 +59,19 @@ class BulkCreateService {
 
       if (tvShowMatcher.matches()) {
         matchTvShowFromFile(tvShowMatcher, fileResult)
+        foundMatch = true
         return fileResult
       }
+    }
+
+    if(foundMatch){
+      return fileResult
     }
 
     def movieMatcher = fileName =~ '(?i)' + movieRegex
     if (movieMatcher.matches()) {
       matchMovieFromFile(movieMatcher, fileResult, movieRegex)
+      foundMatch = true
       return fileResult
     }
 

--- a/grails-app/services/streama/BulkCreateService.groovy
+++ b/grails-app/services/streama/BulkCreateService.groovy
@@ -50,7 +50,6 @@ class BulkCreateService {
 
   private matchSingleFile(file, movieRegex, List tvShowRegexList) {
     def fileResult = [file: file.path]
-    def foundMatch = false
 
     String fileName = file.name
 
@@ -59,19 +58,13 @@ class BulkCreateService {
 
       if (tvShowMatcher.matches()) {
         matchTvShowFromFile(tvShowMatcher, fileResult)
-        foundMatch = true
         return fileResult
       }
-    }
-
-    if(foundMatch){
-      return fileResult
     }
 
     def movieMatcher = fileName =~ '(?i)' + movieRegex
     if (movieMatcher.matches()) {
       matchMovieFromFile(movieMatcher, fileResult, movieRegex)
-      foundMatch = true
       return fileResult
     }
 


### PR DESCRIPTION
## CHANGES

Change the default movie regex to use negative check `[^\(\[]*` instead of `.*` for group Names. This prevents regex from going over the actual year and hitting something like 1080.

Example movie name:
`1. Die Hard (1988) BDRip 1080p H.265 [2xUKR_ENG].mkv`


## PROPOSED

I would prefer having regexes encapsulated into a separate class so they could be tested with a set of possible cases to make sure that any changes to regexes don't break anything. Thinking about including into this PR.
