### PR TITLE
Bugfix - Properly closed manually-uploaded episode file InputStream

### DIFF
--- a/grails-app/services/streama/UploadService.groovy
+++ b/grails-app/services/streama/UploadService.groovy
@@ -34,7 +34,7 @@ class UploadService {
     //log.debug(params)
     def rawFile = request.getFile('file')
     def mimetype = rawFile.contentType
-    def sha256Hex = DigestUtils.sha256Hex(rawFile.inputStream)
+    def sha256Hex = rawFile.inputStream.withStream { stream -> DigestUtils.sha256Hex(stream) }
     def index = rawFile.originalFilename.lastIndexOf('.')
     String extension = rawFile.originalFilename[index..-1];
     def originalFilenameNoExt = rawFile.originalFilename[0..(index-1)]


### PR DESCRIPTION
Closed the upload file InputStream after uploading a TV show episode through the "Manage Files" button of an episode.

Launching the jar, after uploading multiple big files (TV show episodes) through the "Manage Files" button on the web interface, I was getting "java.io.IOException: No space left on device" on the console, and my 100% full /tmp partition would only free up the used disk space after killing the streama process. This was both in Ubuntu 18.04 LTS and Arch Linux VMs. Streama version v1.7.3.

Closing the uploaded file InputStream in UploadService.upload(request, params) method after it is no longer needed seems to correctly free up the disk space without having to run out, and having to kill and restart the application every time. Though I used v1.7.3, the InputStream still seems to not get properly closed properly on the current master branch.