### PR TITLE
Fix "Installation and first-time setup" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you want to donate to the developer via bitcoin use 17rCUEX6KYQ8ZM4w39ttEUL7S
 - [License](#license)
 
 # Getting Started
-- [Installation and first-time setup](https://streamaserver.org/getting-started/installing/)
+- [Installation and first-time setup](https://docs.streama-project.com/getting-started/installing/)
 
 If you have any issues getting started, feel free to [chat with us on Discord](https://discord.gg/CJEHWX9). We are more than happy to assist and then improve the docs accordingly. 
 


### PR DESCRIPTION
The old link was dead, so relinked to same path on docs.streama-project.com