### PR TITLE
Recursively add files in Bulk-Create

### DIFF
--- a/grails-app/assets/javascripts/streama/controllers/createFromFileCtrl.modal.js
+++ b/grails-app/assets/javascripts/streama/controllers/createFromFileCtrl.modal.js
@@ -139,14 +139,27 @@ function modalCreateFromFileCtrl($scope, $uibModalInstance, apiService, uploadSe
 		directory.isSelected = !directory.isSelected;
 	  if(directory.isSelected){
       openLocalDirectory(directory, true, function () {
-        _.forEach(directory.localFiles, function (file) {
-          toggleSelection(file);
+        _.forEach(directory.localFiles, function (content) {
+			if(content.path.split('\\').pop().split('.').length > 1){
+				toggleSelection(content);
+			}else{
+				openLocalDirectory(content, true, function () {
+				_.forEach(content.localFiles, function (file) {
+				  toggleSelection(file);
+						});
+					});
+			};
         });
       });
     }else{
       _.forEach(directory.localFiles, function (file) {
         deselect(file);
         directory.showFiles = false;
+		file.showFiles = false;
+		_.forEach(file.localFiles, function (subfile) {
+				deselect(subfile);
+				subfile.showFiles = false;
+				});
       });
     }
 


### PR DESCRIPTION
This is aiming to fix issue #691 

Currently "Bulk-Create from file(s)" only selects files directly inside the selected directory, but not in subdirectories.

Here, when selecting a directory in "Bulk-Create from file(s)", all files directly in this main path will be selected and additionally all further files in first level subdirectories. These can then be parsed from imdb, without having to select files individually from all subdirectories.

As an example, assume the TV_Shows directory is mounted and has an example "Show_1" as below.

**/mnt/TV_Shows/**
...
   **Show_1**
   ----_Season_1_
   -------S01E01.mp4
   -------S01E02.mp4
   ----_Season_2_
   -------S02E01.mp4
   -------S02E02.mp4
   ----Special_episode.mkv
...
	
By selecting directory Show_1, all episodes in the Season_1_and Season_2 directories are also selected, plus the Special_episode.mkv file that is in the main Show_1 directory.
