### PR TITLE
Adjust Up Next timer on videos as function of duration

### DIFF
--- a/grails-app/assets/javascripts/streama/directives/streama-video-player-directive.js
+++ b/grails-app/assets/javascripts/streama/directives/streama-video-player-directive.js
@@ -318,7 +318,8 @@ angular.module('streama').directive('streamaVideoPlayer', [
             $scope.isNextVideoShowing = (nextVideoId && video.currentTime > videoOutroStart);
           } else {
             var remainingDurationSeconds = video.duration - video.currentTime;
-            $scope.isNextVideoShowing = (nextVideoId && remainingDurationSeconds < END_OF_VIDEO);
+			var endOfVideo = Math.min(Math.max(3, video.duration * 0.042), END_OF_VIDEO);
+            $scope.isNextVideoShowing = (nextVideoId && remainingDurationSeconds < endOfVideo);
           }
         }
 


### PR DESCRIPTION
Approach to fix issue #1055 

Instead of a fixed 30 s timeout from the end of videos before an "Up Next" popup shows, this will adjust the time gradually.

I used a 5 second timeout for a 2 minute video as a guideline, I believe this is reasonable for a short video. This ratio is then used between a minimum timeout of 3 seconds and a maximum of 30 seconds (`END_OF_VIDEO`).