### PR TITLE
Allow normal user to mark video unwatched

### DIFF
--- a/grails-app/conf/application.groovy
+++ b/grails-app/conf/application.groovy
@@ -52,6 +52,7 @@ grails.plugin.springsecurity.controllerAnnotations.staticRules = [
   [pattern:'/settings/index',  access :['IS_AUTHENTICATED_REMEMBERED']],
   [pattern:'/report/save',  access :['IS_AUTHENTICATED_REMEMBERED']],
   [pattern:'/video/markCompleted',  access :['IS_AUTHENTICATED_REMEMBERED']],
+  [pattern:'/video/markAsUnviewed',  access :['IS_AUTHENTICATED_REMEMBERED']],
 
   [pattern:'/subtitles/get',  access :['IS_AUTHENTICATED_REMEMBERED']],
   [pattern:'/subtitles/download',  access :['IS_AUTHENTICATED_REMEMBERED']],


### PR DESCRIPTION
When logged in as a normal user, marking a video as unviewed would result in a "You don't have permission" error, while it was working fine for an admin user. This enables the "Mark as unviewed" feature for non-admin users as well.

(see https://github.com/streamaserver/streama/issues/1040#issuecomment-781658966)