### PR TITLE
Fixing error adding tv shows to watchlist

### DIFF
--- a/grails-app/controllers/streama/WatchlistEntryController.groovy
+++ b/grails-app/controllers/streama/WatchlistEntryController.groovy
@@ -101,7 +101,7 @@ class WatchlistEntryController {
       user == currentUser
       profile == currentProfile
       isDeleted == false
-      video != null
+      video != null || tvShow != null
     }.list(sort: sortingColumn, order: sortingOrder)
     if(!watchlistEntries){
       render status: NO_CONTENT

--- a/grails-app/services/streama/marshallers/MarshallerService.groovy
+++ b/grails-app/services/streama/marshallers/MarshallerService.groovy
@@ -486,13 +486,7 @@ class MarshallerService {
         response['lastUpdated'] = watchlistEntry.lastUpdated
 
         response['tvShow'] = watchlistEntry.tvShow
-        response['video'] = [
-          id: watchlistEntry.video.id,
-          mediaType: watchlistEntry.video.getType(),
-          poster_path: watchlistEntry.video.getPosterPath(),
-          inWatchlist: watchlistEntry.video.inWatchlist(),
-          release_date: watchlistEntry.video.getReleaseDate()
-        ]
+        response['video'] = watchlistEntry.video
 
         return response
       }


### PR DESCRIPTION
TV shows currently have a error adding to watchlist, due to the fact that they don't have a `video` property and specific properties inside the `video` object are extracted during this addition. 

I changed this so that it it simply assigns `response["tvShow"]` to the `tvShow` object and the `response["video"]` to the `video` objects. This way one of them can be `null` (as will always happen) and it will be added without errors to the list.

The second problem is that TV shows aren't even shown in the watchlist, because, again, their Entry don't have a `video` property and during `list` it was filtered by `video!=null`, which fails. 
I changed it so that it checks for `video!=null || tvShow!=null`. This way it prevents completely `null` entries and it works for both shows and movies.