### PR TITLE
[Docker] Mysql build error for Apple M1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   mysql:
+    platform: linux/x86_64
     image: mysql:5.7
     restart: always
     container_name: mysql


### PR DESCRIPTION
When I setup with docker I got error:

```sh
❯ docker-compose pull
Pulling mysql         ... pulling from library/mysql
Pulling streama       ... done
Pulling proxy-reverse ... done

ERROR: for mysql  no matching manifest for linux/arm64/v8 in the manifest list entries
ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries
```

And I fixed